### PR TITLE
新規作成・削除実行後、値を更新する

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,12 +2,16 @@ import { BrowserRouter } from 'react-router-dom';
 import { Router } from './router/Router';
 import './App.css';
 
+import { PostProvider } from './providers/PostProvider';
+
 function App() {
   return (
-    <BrowserRouter>
-      <h1>TODOアプリ</h1>
-      <Router/>
-    </BrowserRouter>
+    <PostProvider>
+      <BrowserRouter>
+        <h1>TODOアプリ</h1>
+        <Router/>
+      </BrowserRouter>
+    </PostProvider>
   );
 }
 

--- a/frontend/src/components/pages/post/PostCreatePage.tsx
+++ b/frontend/src/components/pages/post/PostCreatePage.tsx
@@ -13,7 +13,9 @@ export const PostCreatePage: VFC = memo(() => {
 
   const onClickCreatePost = () => {
     PostCreate(inputPostTitle,inputPostDetails);
-    history.push("/post");
+    //ここで値を更新したい！
+    // setPosts(posts.filter(post => post.id ＋？ postId)) //今回作成したものを追加して更新する
+    history.push("/post"); //もしくはここで渡す？
   }
 
   return (

--- a/frontend/src/components/pages/post/PostIndexPage.tsx
+++ b/frontend/src/components/pages/post/PostIndexPage.tsx
@@ -1,29 +1,34 @@
-import React, { useState, useEffect, useCallback, FC} from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import axios from 'axios'
 
 import { postsIndexUrl } from '../../../urls';
 import { TodoType } from '../../../types/api/post';
 import { PostDelete } from '../../../hooks/usePostDelete';
+// import { PostContext } from '../../../providers/PostProvider';
 
-export const PostIndexPage: FC = () => {
+
+export const PostIndexPage = () => {
   const history = useHistory();
   const onClickPostEditPage = useCallback(() => history.push("/post/edit"),[history]);
   const onClickPostCreatePage = useCallback(() => history.push("/post/new"),[history]);
 
-  const [posts, setPosts] = useState<Array<TodoType>>([])
+  //これを呼びたい！使いたい！
+  // const { posts, setPosts } = useContext(PostContext);
 
-  const onClickPostDelete = (postId: number) => {
-    PostDelete(postId);
-    setPosts(posts.filter(post => post.id !== postId))
-  }
+  const [posts, setPosts] = useState<Array<TodoType>>([])
 
   useEffect(() => {
     axios.get<Array<TodoType>>(postsIndexUrl)
     .then(res => {
       setPosts(res.data);
     })
-  },[])
+  },[setPosts])
+
+  const onClickPostDelete = (postId: number) => {
+    PostDelete(postId);
+    setPosts(posts.filter(post => post.id !== postId))
+  }
 
   return (
       <div>

--- a/frontend/src/hooks/usePostCreate.ts
+++ b/frontend/src/hooks/usePostCreate.ts
@@ -12,11 +12,9 @@ export const PostCreate =(title: string, details: string) => {
       })
       .then(res => {
           console.log(res);
-          alert("新規作成しました");
-          // alert(`${data.title}を登録完了`);
+          window.location.reload() //TODO: 将来stateに置き換える
         })
         .catch(error => {
           console.log(error);
-          alert("作成できませんでした");
         });
 }

--- a/frontend/src/hooks/usePostDelete.ts
+++ b/frontend/src/hooks/usePostDelete.ts
@@ -6,10 +6,8 @@ export const PostDelete =(postId: number) => {
   axios.delete( postsDeleteUrl(postId))
   .then(res => {
       console.log(res);
-      alert("削除しました");
     })
     .catch(error => {
       console.log(error);
-      alert("削除できませんでした");
     });
 }

--- a/frontend/src/providers/PostProvider.tsx
+++ b/frontend/src/providers/PostProvider.tsx
@@ -1,0 +1,25 @@
+// TODO: 後日ここで定義したstateを使いたい
+
+import React, {ReactNode, useState, createContext  } from "react";
+import { TodoType } from "../types/api/post";
+
+export const PostContext = createContext({});
+
+type PostType = {
+  id?: number;
+  // user_id: number;
+  title?: string;
+  details?: string;
+  children?: ReactNode;
+};
+
+export const PostProvider = (props: PostType) => {
+  const { children } = props;
+  const [posts, setPosts] = useState<Array<TodoType>>([])
+
+  return (
+    <PostContext.Provider value= {{ posts, setPosts} }>
+       {children}
+    </PostContext.Provider>
+  );
+};


### PR DESCRIPTION
## 実装の目的と概要
- 新規作成・削除実行後、値を更新する

## 実装内容(技術的な点を記載)
### Createアクション:
- useContextでグローバルなStateを作成し、setPostsで値を更新→タイムアップで実装できず。
- 代案として、` window.location.reload() `で自動で更新を入れるようにして実現
- 将来的気には、当初の内容での実装を目指す

### deleteアクション
- `PostIndex.tsx`に記載されているStateを活用し、値を削除した値以外の値を渡すことで実装
- こちらも将来的にはグローバルなStateを用いて共通化する。

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか

