### PR TITLE
404ページのルーディングを実装

### DIFF
--- a/frontend/src/components/pages/Page404.tsx
+++ b/frontend/src/components/pages/Page404.tsx
@@ -1,18 +1,27 @@
-import { Flex, Heading } from "@chakra-ui/react";
+import { Box, Flex, Heading } from "@chakra-ui/react";
 import { memo, VFC } from "react";
+import { Link } from "react-router-dom";
+
 
 export const Page404: VFC = memo(() => {
+
   return (
     <>
     <Flex align="center" justify="center" height="60vh">
-      <Heading as="h1"
-               size="2xl"
-               textAlign="center"
-               py={4}
-      >
-        PAGE 404
-      </Heading>
+      <Box>
+        <Heading as="h1"
+                 size="2xl"
+                 textAlign="center"
+                 py={4}
+        >
+          PAGE 404
+        </Heading>
+        <Box pt={4} align="center">
+          <Link to="/posts">TOPへ戻る</Link>
+        </Box>
+      </Box>
       </Flex>
+
     </>
 )});
   

--- a/frontend/src/components/pages/Page404.tsx
+++ b/frontend/src/components/pages/Page404.tsx
@@ -1,7 +1,19 @@
+import { Flex, Heading } from "@chakra-ui/react";
 import { memo, VFC } from "react";
 
 export const Page404: VFC = memo(() => {
-  return <p>404ページです</p>
-});
+  return (
+    <>
+    <Flex align="center" justify="center" height="60vh">
+      <Heading as="h1"
+               size="2xl"
+               textAlign="center"
+               py={4}
+      >
+        PAGE 404
+      </Heading>
+      </Flex>
+    </>
+)});
   
 

--- a/frontend/src/router/PostRoutes.tsx
+++ b/frontend/src/router/PostRoutes.tsx
@@ -13,10 +13,10 @@ export const PostRoutes = [
     exact: false,
     children: <PostCreatePage/>
   },
+  //todo: 正常値を渡さない場合のエラー対応を実装する
   {
     path: "/:postId",
     exact: false,
     children: <PostEditPage/>
   },
-  
 ];

--- a/frontend/src/router/Router.tsx
+++ b/frontend/src/router/Router.tsx
@@ -58,13 +58,15 @@ export const Router: VFC = memo(() => {
               </HeaderLayout>
             </Route>
           ))}
+
         </Switch>
       )}>
       </Route>
+
+      </LoginUserProvider>
       <Route path ="*">
         <Page404/>
       </Route>
-      </LoginUserProvider>
     </Switch>
   )
 });

--- a/frontend/src/router/Router.tsx
+++ b/frontend/src/router/Router.tsx
@@ -13,60 +13,60 @@ import { Page404 } from "../components/pages/Page404";
 
 export const Router: VFC = memo(() => {
   return(
-    <Switch>
-      <LoginUserProvider>
-      <Route path="/login">
-        <HeaderLayout>
-          <LoginPage/>
-        </HeaderLayout>
-      </Route>
-
-      <Route path="/signup">
-        <HeaderLayout>
-          <SignUpPage />
-        </HeaderLayout>
-      </Route>
-
-      <Route path="/user/edit">
-        <HeaderLayout>
-          <UserEditPage />
-        </HeaderLayout>
-      </Route>
-
-      <Route path="/password">
-        <HeaderLayout>
-          <PasswordEditPage />
-        </HeaderLayout>
-      </Route>
-
-      <Route path="/mypage">
-        <HeaderLayout>
-          <MyPage/>
-        </HeaderLayout>
-      </Route>
-
-      <Route 
-        path="/posts"render = {({ match: { url }}) => (
-        <Switch>
-          {PostRoutes.map((route) => (
-            <Route
-              key={route.path}
-              exact={route.exact}
-              path={`${url}${route.path}`}>
-              <HeaderLayout>
-                { route.children }
-              </HeaderLayout>
-            </Route>
-          ))}
-
-        </Switch>
-      )}>
-      </Route>
-
-      </LoginUserProvider>
-      <Route path ="*">
-        <Page404/>
-      </Route>
-    </Switch>
+    <LoginUserProvider>
+      <Switch>
+        <Route path="/login">
+          <HeaderLayout>
+            <LoginPage/>
+          </HeaderLayout>
+        </Route>
+  
+        <Route path="/signup">
+          <HeaderLayout>
+            <SignUpPage />
+          </HeaderLayout>
+        </Route>
+  
+        <Route path="/user/edit">
+          <HeaderLayout>
+            <UserEditPage />
+          </HeaderLayout>
+        </Route>
+  
+        <Route path="/password">
+          <HeaderLayout>
+            <PasswordEditPage />
+          </HeaderLayout>
+        </Route>
+  
+        <Route path="/mypage">
+          <HeaderLayout>
+            <MyPage/>
+          </HeaderLayout>
+        </Route>
+  
+        <Route 
+          path="/posts"render = {({ match: { url }}) => (
+          <Switch>
+            {PostRoutes.map((route) => (
+              <Route
+                key={route.path}
+                exact={route.exact}
+                path={`${url}${route.path}`}>
+                <HeaderLayout>
+                  { route.children }
+                </HeaderLayout>
+              </Route>
+            ))}
+  
+          </Switch>
+        )}>
+        </Route>
+  
+        <Route path ="*">
+          <Page404 />
+        </Route>
+      </Switch>
+    </LoginUserProvider>
   )
 });

--- a/frontend/src/router/Router.tsx
+++ b/frontend/src/router/Router.tsx
@@ -9,6 +9,7 @@ import { LoginUserProvider } from "../providers/LoginUserProvider";
 import { SignUpPage } from "../components/pages/user/SignUpPage";
 import { UserEditPage } from "../components/pages/user/UserEditPage";
 import { PasswordEditPage } from "../components/pages/user/PasswordEditPage";
+import { Page404 } from "../components/pages/Page404";
 
 export const Router: VFC = memo(() => {
   return(
@@ -59,6 +60,9 @@ export const Router: VFC = memo(() => {
           ))}
         </Switch>
       )}>
+      </Route>
+      <Route path ="*">
+        <Page404/>
       </Route>
       </LoginUserProvider>
     </Switch>


### PR DESCRIPTION
## 実装の目的と概要
- 404ページのルーディングを実装

## 実装内容(技術的な点を記載)
- 404ページのルーディングを実装
- 404ページのレイアウトを調整


## スクリーンショット（画面レイアウトを変更した場合）

<img width="839" alt="スクリーンショット 2021-08-31 9 08 23" src="https://user-images.githubusercontent.com/64491435/131421269-11406a24-9676-4ac8-9290-24e4c7bf0527.png">




## つまづいた部分
- 404ページが全てのページでレンダリングされてしまう
→ prividerを外の出してあげることで、正常に動作した。

- after
```js
<Provider>
  <Switch>
    <Route>

    </Route>
  </Switch>
</Provider>

//swichよりも外にprividerを定義するようにする
```
