### PR TITLE
PostProviderの実装

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,20 +6,23 @@ import { Router } from "./router/Router";
 import "./App.css";
 import { HeaderLayout } from "./components/templates/HeaderLayout";
 import { LoginUserProvider } from "./providers/LoginUserProvider";
+import { PostProvider } from "./providers/PostProvider";
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 function App() {
   return (
     <LoginUserProvider>
-      <ChakraProvider theme={theme}>
-        <BrowserRouter>
-          <HeaderLayout>
-            <Box m={16}>
-              <Router />
-            </Box>
-          </HeaderLayout>
-        </BrowserRouter>
-      </ChakraProvider>
+      <PostProvider>
+        <ChakraProvider theme={theme}>
+          <BrowserRouter>
+            <HeaderLayout>
+              <Box m={16}>
+                <Router />
+              </Box>
+            </HeaderLayout>
+          </BrowserRouter>
+        </ChakraProvider>
+      </PostProvider>
     </LoginUserProvider>
   );
 }

--- a/frontend/src/components/organisms/post/PostCard.tsx
+++ b/frontend/src/components/organisms/post/PostCard.tsx
@@ -27,8 +27,6 @@ export const PostCard: VFC<Props> = memo((props) => {
 
   const onClickPostDelete = useCallback((postId: number) => {
     deletePost(postId);
-    window.location.reload();
-    // setPosts(posts.filter(post => post.id !== post.id)) //将来的にこちらに置き換える
   }, []);
 
   return (

--- a/frontend/src/components/pages/post/PostIndexPage.tsx
+++ b/frontend/src/components/pages/post/PostIndexPage.tsx
@@ -5,6 +5,14 @@ import { useHistory } from "react-router-dom";
 import { PostCard } from "../../organisms/post/PostCard";
 import { usePostIndex } from "../../../hooks/usePostIndex";
 
+type Posts = {
+  id: number;
+  title: string;
+  details: string;
+  user_id: number;
+  user: { name: string };
+};
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const PostIndexPage = memo(() => {
   const history = useHistory();
@@ -13,7 +21,6 @@ export const PostIndexPage = memo(() => {
     [history]
   );
   const { getPosts, posts } = usePostIndex();
-  // todo: postsを持っていない場合のみ取得する
   useEffect(() => getPosts(), []);
 
   return (
@@ -26,8 +33,7 @@ export const PostIndexPage = memo(() => {
           新規作成
         </Button>
       </Box>
-      {posts.map((post) => (
-        // eslint-disable-next-line react/jsx-key
+      {posts.map((post: Posts) => (
         <PostCard
           key={post.id}
           postUserId={post.user_id}

--- a/frontend/src/hooks/usePostCreate.ts
+++ b/frontend/src/hooks/usePostCreate.ts
@@ -1,14 +1,16 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useContext } from "react";
 import axios from "axios";
 import { useHistory } from "react-router-dom";
 
 import { postsCreateUrl } from "../urls";
 import { useMessage } from "./useMessage";
+import { PostContext } from "../providers/PostProvider";
 
 export const usePostCreate = () => {
   const history = useHistory();
   const { showMessage } = useMessage();
   const [createLoading, setCreateLoading] = useState(false);
+  const { posts, setPosts } = useContext(PostContext);
   const localStrageData = localStorage.getItem("LoginUser") as string;
   const loginUserData = JSON.parse(localStrageData);
 
@@ -26,6 +28,7 @@ export const usePostCreate = () => {
       .then((res) => {
         console.log(res);
         setCreateLoading(false);
+        setPosts([...posts, res.data]);
         showMessage({ title: "投稿を作成しました", status: "success" });
         history.push("/posts");
       })

--- a/frontend/src/hooks/usePostIndex.ts
+++ b/frontend/src/hooks/usePostIndex.ts
@@ -1,23 +1,15 @@
-import { useCallback, useState } from "react";
+import { useCallback, useContext } from "react";
 import axios from "axios";
 
 import { postsIndexUrl } from "../urls";
-
-type Posts = {
-  id: number;
-  title: string;
-  details: string;
-  user_id: number;
-  user: { name: string };
-};
+import { PostContext } from "../providers/PostProvider";
 
 export const usePostIndex = () => {
-  const [posts, setPosts] = useState<Array<Posts>>([]);
+  const { posts, setPosts } = useContext(PostContext);
   const getPosts = useCallback(() => {
     axios
       .get(postsIndexUrl)
       .then((res) => {
-        console.log(res.data);
         setPosts(res.data);
       })
       .catch((error) => {

--- a/frontend/src/hooks/useUserPasswordUpdate.ts
+++ b/frontend/src/hooks/useUserPasswordUpdate.ts
@@ -29,8 +29,7 @@ export const useUserPasswordUpdate = () => {
         "Content-Type": "application/json",
       })
       .then((res) => {
-
-      setLoginUser({
+        setLoginUser({
           userId: loginUserData[`user_id`],
           name: loginUserData[`name`],
           email: loginUserData[`email`],

--- a/frontend/src/providers/PostProvider.tsx
+++ b/frontend/src/providers/PostProvider.tsx
@@ -1,0 +1,37 @@
+import {
+  createContext,
+  ReactNode,
+  useState,
+  Dispatch,
+  SetStateAction,
+} from "react";
+
+type Posts = {
+  id: number;
+  title: string;
+  details: string;
+  user_id: number;
+  user: { name: string };
+};
+
+// TOOD: 型をきちんと定義すること。
+type PostsContextType = {
+  posts: Array<Posts>;
+  setPosts: Dispatch<SetStateAction<Array<Posts>>>;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const PostContext = createContext<any>([]);
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const PostProvider = (props: { children: ReactNode }) => {
+  const { children } = props;
+
+  const [posts, setPosts] = useState<Array<PostsContextType>>([]);
+
+  return (
+    <PostContext.Provider value={{ posts, setPosts }}>
+      {children}
+    </PostContext.Provider>
+  );
+};

--- a/frontend/src/types/api/post.ts
+++ b/frontend/src/types/api/post.ts
@@ -4,3 +4,11 @@ export type TodoType = {
   title: string;
   details: string;
 };
+
+export type PostType = {
+  id: number;
+  title: string;
+  details: string;
+  user_id: number;
+  user: { name: string };
+};


### PR DESCRIPTION
## 実装の目的と概要
- PostProviderを実装し、グローバルなStateを定義
- 作成したStateを用いて、Index/Create/Deleteを実行する

## 実装内容(技術的な点を記載)
- PostProviderを作成(createContext)
- Indexアクションで、PostProviderで定義した値を使用(useContext)
- Createアクションで、PostProviderで定義した値を使用(useContext, スプレッド構文)
- Deleteアクションで、PostProviderで定義した値を使用(useContext, fileter)
- 上記動作の動作を確認

## スクリーンショット（画面レイアウトを変更した場合）
- 削除したときに、メッセージが表示できるようになった。
<img width="839" alt="スクリーンショット 2021-09-09 9 05 03" src="https://user-images.githubusercontent.com/64491435/132602255-3c6b9dae-939f-4ff5-b4c2-3609c5b55037.png">




## 備考（実装していないことなど）
- createContextの型定義の理解が浅い。型の統一するタスクにて理解を深め、修正する
- postDelete実行するとき、1回目はsetPostsで値が更新されるが、2回目は値が更新されないため、表示が変わらない現象が発生している。型定義でanyを使用しているためだと思われるので、別タスクで修正する
