### PR TITLE
パスワードを編集するとき、現在のパスワードも要求する

### DIFF
--- a/app/controllers/v1/auth/passwords_controller.rb
+++ b/app/controllers/v1/auth/passwords_controller.rb
@@ -1,6 +1,42 @@
 module V1
   module Auth
     class PasswordsController < DeviseTokenAuth::PasswordsController
+      before_action :authenticate_v1_user!, only: %i[update]
+      before_action :set_params, only: %i[update]
+
+      def update
+        if !chack_input_password
+          render json: { messages: "新しいパスワードが一致しません" }, status: :unprocessable_entity
+        elsif !chack_same_password
+          render json: { messages: "現在のパスワードと新しいパスワードが同じです。" }, status: :unprocessable_entity
+        elsif !check_now_password
+          render json: { messages: "現在のパスワードが一致しません" }, status: :unprocessable_entity
+        else
+          super
+        end
+      end
+
+      private
+
+      def resource_params
+        params.permit(:now_password, :password, :password_confirmation, :reset_password_token)
+      end
+
+      def set_params
+        @params = resource_params
+      end
+
+      def chack_input_password
+        params[:password] == params[:password_confirmation]
+      end
+
+      def chack_same_password
+        params[:password] != params[:now_password]
+      end
+
+      def check_now_password
+        current_v1_user.valid_password?(@params[:now_password])
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   namespace :v1 do
     mount_devise_token_auth_for "User", at: "auth", controllers: {
-      registrations: "v1/auth/registrations"
+      registrations: "v1/auth/registrations",
+      passwords: "v1/auth/passwords"
     }
     resources :posts
   end

--- a/frontend/src/components/pages/user/PasswordEditPage.tsx
+++ b/frontend/src/components/pages/user/PasswordEditPage.tsx
@@ -14,6 +14,7 @@ import { useUserValidate } from "../../../hooks/useUserValidate";
 import { GoBackButton } from "../../atms/button/GoBackButton";
 
 export const PasswordEditPage: VFC = memo(() => {
+  const [inputNowUserPassword, setInputNowUserPassword] = useState<string>("");
   const [inputUserPassword, setInputUserPassword] = useState<string>("");
   const [inputConformPassword, setInputConformPassword] = useState<string>("");
 
@@ -23,6 +24,11 @@ export const PasswordEditPage: VFC = memo(() => {
     validateEditUserPassword,
     validateEditConformPassword,
   } = useUserValidate();
+
+  const onChangeInputNowUserPassword = (e: ChangeEvent<HTMLInputElement>) => {
+    const nowPassword = e.target.value;
+    setInputNowUserPassword(nowPassword);
+  };
 
   const onChangeInputUserPassword = (e: ChangeEvent<HTMLInputElement>) => {
     const password = e.target.value;
@@ -40,7 +46,11 @@ export const PasswordEditPage: VFC = memo(() => {
 
   //更新ボタン
   const onClickPasswordUpdate = () => {
-    userPasswordUpdate(inputUserPassword);
+    userPasswordUpdate(
+      inputUserPassword,
+      inputConformPassword,
+      inputNowUserPassword
+    );
   };
 
   return (
@@ -53,6 +63,14 @@ export const PasswordEditPage: VFC = memo(() => {
           </Heading>
           <Divider my={4}></Divider>
           <Stack spacing={4} py={4} px={6}>
+            <p>現在のパスワード</p>
+            <Input
+              placeholder="現在のパスワード"
+              type="password"
+              value={inputNowUserPassword}
+              onChange={onChangeInputNowUserPassword}
+            />
+
             <p>新しいパスワード</p>
             <Input
               placeholder="パスワード"
@@ -66,7 +84,7 @@ export const PasswordEditPage: VFC = memo(() => {
 
             <p>新しいパスワード(確認用)</p>
             <Input
-              placeholder="パスワード"
+              placeholder="パスワード(確認用)"
               type="password"
               value={inputConformPassword}
               onChange={onChangeInputConformPassword}
@@ -81,7 +99,7 @@ export const PasswordEditPage: VFC = memo(() => {
               onClick={onClickPasswordUpdate}
               isLoading={loading}
               isDisabled={
-                !!inputUserPasswordError || !!inputConformPasswordError
+                !!inputUserPasswordError || !!inputConformPasswordError || !inputNowUserPassword
               }
             >
               更新する

--- a/frontend/src/hooks/useUserPasswordUpdate.ts
+++ b/frontend/src/hooks/useUserPasswordUpdate.ts
@@ -16,42 +16,49 @@ export const useUserPasswordUpdate = () => {
   const [loading, setLoading] = useState(false);
   const { loginUserData } = useLocalStrage();
 
-  const userPasswordUpdate = useCallback((password: string) => {
-    setLoading(true);
+  const userPasswordUpdate = useCallback(
+    (password: string, password_confirmation: string, now_password: string) => {
+      setLoading(true);
 
-    axios
-      .put(UserPwUPdateUrl, {
-        password: password,
-        password_confirmation: password,
-        uid: loginUser?.uid,
-        "access-token": loginUser?.accessToken,
-        client: loginUser?.client,
-      })
-      .then((res) => {
-        setLoginUser({
-          userId: loginUserData[`user_id`],
-          name: loginUserData[`name`],
-          email: loginUserData[`email`],
-          accessToken: loginUserData[`access-token`],
-          client: loginUserData[`client`],
-          uid: loginUserData[`uid`],
+      axios
+        .put(UserPwUPdateUrl, {
+          password: password,
+          password_confirmation: password,
+          now_password: now_password,
+          uid: loginUser?.uid,
+          "access-token": loginUser?.accessToken,
+          client: loginUser?.client,
+        })
+        .then((res) => {
+          setLoginUser({
+            userId: loginUserData[`user_id`],
+            name: loginUserData[`name`],
+            email: loginUserData[`email`],
+            accessToken: loginUserData[`access-token`],
+            client: loginUserData[`client`],
+            uid: loginUserData[`uid`],
+          });
+          showMessage({
+            title: "ユーザーのパスワードを更新しました",
+            status: "success",
+          });
+          setUserLoginStatus(true);
+          setLoading(false);
+          history.push("/mypage");
+        })
+        .catch((error) => {
+          setLoading(false);
+          showMessage({
+            title: `${error.response.data.messages}`,
+            status: "error",
+          });
+          // showMessage({
+          //   title: "ユーザーパスワードの更新に失敗しました。",
+          //   status: "error",
+          // });
         });
-        showMessage({
-          title: "ユーザーのパスワードを更新しました",
-          status: "success",
-        });
-        setUserLoginStatus(true);
-        setLoading(false);
-        history.push("/mypage");
-      })
-      .catch((error) => {
-        console.log(error);
-        setLoading(false);
-        showMessage({
-          title: "ユーザーパスワードの更新に失敗しました。",
-          status: "error",
-        });
-      });
-  }, []);
+    },
+    []
+  );
   return { userPasswordUpdate, loading };
 };

--- a/frontend/src/hooks/useUserPasswordUpdate.ts
+++ b/frontend/src/hooks/useUserPasswordUpdate.ts
@@ -23,7 +23,7 @@ export const useUserPasswordUpdate = () => {
       axios
         .put(UserPwUPdateUrl, {
           password: password,
-          password_confirmation: password,
+          password_confirmation: password_confirmation,
           now_password: now_password,
           uid: loginUser?.uid,
           "access-token": loginUser?.accessToken,
@@ -52,10 +52,6 @@ export const useUserPasswordUpdate = () => {
             title: `${error.response.data.messages}`,
             status: "error",
           });
-          // showMessage({
-          //   title: "ユーザーパスワードの更新に失敗しました。",
-          //   status: "error",
-          // });
         });
     },
     []

--- a/spec/requests/auth/passwords_spec.rb
+++ b/spec/requests/auth/passwords_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe "Auth::Passwords", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## 実装の目的と概要
- パスワードを編集するとき、現在のパスワードも要求する

## 実装内容(技術的な点を記載)
- パスワードを検証する条件分岐を実装(`passwords_controller.rb`)
- ルーティングを追加
- `PasswordEditPage.tsx`に入力フォームを追加
- axiosでnowpasswordをhttpリクエストに追加
- paramsによって、エラーメッセージを条件分岐
-  現在のパスワードが入力されていない場合、送信ボタンをクリックできない


## スクリーンショット（画面レイアウトを変更した場合）

<img width="840" alt="現在のパスワードと新しいパスワードが一致している場合" src="https://user-images.githubusercontent.com/64491435/134765098-add8065c-f191-46f0-94f2-49d9212590d6.png">
<img width="840" alt="現在のパスワードが違う場合" src="https://user-images.githubusercontent.com/64491435/134765100-99108e01-b9c0-487b-9680-f16debb4e463.png">
<img width="840" alt="新しいパスワードが不一致の場合" src="https://user-images.githubusercontent.com/64491435/134765101-9104cb3d-ee8e-41bc-a728-6913c9b4ec08.png">

## 参考資料
- [ DeviseTokenAuth::ApplicationController](https://github.com/lynndylanhurley/devise_token_auth/blob/master/app/controllers/devise_token_auth/passwords_controller.rb#L3)
- [devise_token_authの update password のソースコードを読んでみる](https://kossy-web-engineer.hatenablog.com/entry/2021/03/27/180543)
