### PR TITLE
リクエストスペックの追加/修正

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,3 +51,5 @@ Metrics/AbcSize:
 # クラスのネストを許可
 ClassAndModuleChildren:
   EnforcedStyle: compact
+  Exclude:
+    - "config/application.rb"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,3 +47,7 @@ Metrics/BlockLength:
 
 Metrics/AbcSize:
   Max: 20
+
+# クラスのネストを許可
+ClassAndModuleChildren:
+  EnforcedStyle: compact

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,4 +1,2 @@
-module ApplicationCable
-  class Channel < ActionCable::Channel::Base
-  end
+class ApplicationCable::Channel < ActionCable::Channel::Base
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,2 @@
-module ApplicationCable
-  class Connection < ActionCable::Connection::Base
-  end
+class ApplicationCable::Connection < ActionCable::Connection::Base
 end

--- a/app/controllers/v1/auth/passwords_controller.rb
+++ b/app/controllers/v1/auth/passwords_controller.rb
@@ -1,42 +1,38 @@
-module V1
-  module Auth
-    class PasswordsController < DeviseTokenAuth::PasswordsController
-      before_action :authenticate_v1_user!, only: %i[update]
-      before_action :set_params, only: %i[update]
+class V1::Auth::PasswordsController < DeviseTokenAuth::PasswordsController
+  before_action :authenticate_v1_user!, only: %i[update]
+  before_action :set_params, only: %i[update]
 
-      def update
-        if !chack_input_password
-          render json: { messages: "新しいパスワードが一致しません" }, status: :unprocessable_entity
-        elsif !chack_same_password
-          render json: { messages: "現在のパスワードと新しいパスワードが同じです。" }, status: :unprocessable_entity
-        elsif !check_now_password
-          render json: { messages: "現在のパスワードが一致しません" }, status: :unprocessable_entity
-        else
-          super
-        end
-      end
-
-      private
-
-      def resource_params
-        params.permit(:now_password, :password, :password_confirmation, :reset_password_token)
-      end
-
-      def set_params
-        @params = resource_params
-      end
-
-      def chack_input_password
-        params[:password] == params[:password_confirmation]
-      end
-
-      def chack_same_password
-        params[:password] != params[:now_password]
-      end
-
-      def check_now_password
-        current_v1_user.valid_password?(@params[:now_password])
-      end
+  def update
+    if !chack_input_password
+      render json: { messages: "新しいパスワードが一致しません" }, status: :unprocessable_entity
+    elsif !chack_same_password
+      render json: { messages: "現在のパスワードと新しいパスワードが同じです。" }, status: :unprocessable_entity
+    elsif !check_now_password
+      render json: { messages: "現在のパスワードが一致しません" }, status: :unprocessable_entity
+    else
+      super
     end
+  end
+
+  private
+
+  def resource_params
+    params.permit(:now_password, :password, :password_confirmation, :reset_password_token)
+  end
+
+  def set_params
+    @params = resource_params
+  end
+
+  def chack_input_password
+    params[:password] == params[:password_confirmation]
+  end
+
+  def chack_same_password
+    params[:password] != params[:now_password]
+  end
+
+  def check_now_password
+    current_v1_user.valid_password?(@params[:now_password])
   end
 end

--- a/app/controllers/v1/auth/registrations_controller.rb
+++ b/app/controllers/v1/auth/registrations_controller.rb
@@ -1,15 +1,11 @@
-module V1
-  module Auth
-    class RegistrationsController < DeviseTokenAuth::RegistrationsController
-      private
+class V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  private
 
-      def sign_up_params
-        params.permit(:name, :email, :password, :password_confirmation)
-      end
+  def sign_up_params
+    params.permit(:name, :email, :password, :password_confirmation)
+  end
 
-      def account_update_params
-        params.permit(:name, :email)
-      end
-    end
+  def account_update_params
+    params.permit(:name, :email)
   end
 end

--- a/app/controllers/v1/auth/sessions_controller.rb
+++ b/app/controllers/v1/auth/sessions_controller.rb
@@ -1,6 +1,2 @@
-module V1
-  module Auth
-    class SessionsController < DeviseTokenAuth::SessionsController
-    end
-  end
+class V1::Auth::SessionsController < DeviseTokenAuth::SessionsController
 end

--- a/app/controllers/v1/posts_controller.rb
+++ b/app/controllers/v1/posts_controller.rb
@@ -1,48 +1,46 @@
-module V1
-  class PostsController < ApplicationController
-    before_action :authenticate_v1_user!, only: %i[index create update destroy]
-    before_action :set_user_post, only: %i[index create]
-    before_action :set_post, only: %i[update destroy]
+class V1::PostsController < ApplicationController
+  before_action :authenticate_v1_user!, only: %i[index create update destroy]
+  before_action :set_user_post, only: %i[index create]
+  before_action :set_post, only: %i[update destroy]
 
-    def index
-      posts = @user_posts.posts_index
-      render json: posts, include: { user: [:name] }
+  def index
+    posts = @user_posts.posts_index
+    render json: posts, include: { user: [:name] }
+  end
+
+  def create
+    post = @user_posts.new(post_params)
+
+    if post.save
+      render json: post
+    else
+      render json: post.errors.full_messages, status: :unprocessable_entity
     end
+  end
 
-    def create
-      post = @user_posts.new(post_params)
-
-      if post.save
-        render json: post
-      else
-        render json: post.errors.full_messages, status: :unprocessable_entity
-      end
+  def update
+    if @post.update(post_params)
+      render json: @post
+    else
+      render json: @post.errors.full_messages, status: :unprocessable_entity
     end
+  end
 
-    def update
-      if @post.update(post_params)
-        render json: @post
-      else
-        render json: @post.errors.full_messages, status: :unprocessable_entity
-      end
-    end
+  def destroy
+    @post.destroy!
+  end
 
-    def destroy
-      @post.destroy!
-    end
+  private
 
-    private
+  def set_user_post
+    @user_posts = current_v1_user.posts
+  end
 
-    def set_user_post
-      @user_posts = current_v1_user.posts
-    end
+  def set_post
+    @post = current_v1_user.posts.find(params[:id])
+  end
 
-    def set_post
-      @post = current_v1_user.posts.find(params[:id])
-    end
-
-    def post_params
-      params.require(:post).permit(:title, :details)
-    end
+  def post_params
+    params.require(:post).permit(:title, :details)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,8 +19,10 @@ require "action_cable/engine"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-class ReactTsCrudApp::Application < Rails::Application
-  config.load_defaults 6.1
-  config.i18n.default_locale = :ja
-  config.api_only = true
+module ReactTsCrudApp
+  class ::Application < Rails::Application
+    config.load_defaults 6.1
+    config.i18n.default_locale = :ja
+    config.api_only = true
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,10 +19,8 @@ require "action_cable/engine"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module ReactTsCrudApp
-  class Application < Rails::Application
-    config.load_defaults 6.1
-    config.i18n.default_locale = :ja
-    config.api_only = true
-  end
+class ReactTsCrudApp::Application < Rails::Application
+  config.load_defaults 6.1
+  config.i18n.default_locale = :ja
+  config.api_only = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   # 本番環境の設定
-  get "*path", to: "application#fallback_index_html", constraints: lambda { |request|
-    !request.xhr? && request.format.html?
-  }
+  # get "*path", to: "application#fallback_index_html", constraints: lambda { |request|
+  #   !request.xhr? && request.format.html?
+  # }
 
   namespace :v1 do
     mount_devise_token_auth_for "User", at: "auth", controllers: {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8215,12 +8215,6 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
     },
-    "husky": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.2.tgz",
-      "integrity": "sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==",
-      "dev": true
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,11 +40,6 @@
       "prettier --write ."
     ]
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "eslintConfig": {
     "extends": [
       "react-app",
@@ -71,7 +66,6 @@
     "eslint": "^7.32.0",
     "eslint-plugin-functional": "^3.7.0",
     "eslint-plugin-react": "^7.25.1",
-    "husky": "^7.0.2",
     "lint-staged": "^11.1.2",
     "prettier": "^2.3.2"
   }

--- a/frontend/src/hooks/useUserLogin.ts
+++ b/frontend/src/hooks/useUserLogin.ts
@@ -54,7 +54,7 @@ export const useUserLogIn = () => {
       })
       .catch((error) => {
         console.log(error);
-        showMessage({ title: "ログインにできませんでした", status: "error" });
+        showMessage({ title: "ログインできませんでした", status: "error" });
         setLoading(false);
       });
   }, []);

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,23 @@
 FactoryBot.define do
   factory :user do
+    name { Faker::Lorem.characters(number: 8) }
     email { Faker::Internet.free_email }
     password { Faker::Internet.password(min_length: 8) }
+
+    trait :user_invalid do
+      name { Faker::Lorem.characters(number: 8) }
+      email { Faker::Internet.free_email }
+      password { Faker::Internet.password(min_length: 8) }
+    end
+  end
+
+  factory :user_params, class: :user do
+    name { Faker::Lorem.characters(number: 8) }
+    email { Faker::Internet.free_email }
+
+    trait :invalid_params do
+      name { nil }
+      email { nil }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -20,4 +20,14 @@ FactoryBot.define do
       email { nil }
     end
   end
+
+  factory :password_params, class: :user do
+    password { Faker::Internet.password(min_length: 8) }
+    password_confirmation { password }
+
+    trait :invalid_params do
+      password { nil }
+      conform_password { nil }
+    end
+  end
 end

--- a/spec/requests/auth/passwords_spec.rb
+++ b/spec/requests/auth/passwords_spec.rb
@@ -1,7 +1,0 @@
-require "rails_helper"
-
-RSpec.describe "Auth::Passwords", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
-  end
-end

--- a/spec/requests/v1/auth/password_spec.rb
+++ b/spec/requests/v1/auth/password_spec.rb
@@ -1,7 +1,0 @@
-require "rails_helper"
-
-RSpec.describe "V1::Auth::Passwords", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
-  end
-end

--- a/spec/requests/v1/auth/passwords_spec.rb
+++ b/spec/requests/v1/auth/passwords_spec.rb
@@ -1,0 +1,26 @@
+# require "rails_helper"
+
+# RSpec.describe "V1::Auth::Passwords", type: :request do
+#   describe "POST /update" do
+#     # subject { put(v1_user_password_path, headers: headers) }
+
+#     context "トークン認証情報がない場合" do
+#       it "エラーする" do
+#       end
+#     end
+
+#     # 正常値
+#     context "パラメータが正常な場合" do
+#       it "更新できる" do
+#       end
+#     end
+
+#     # 異常値
+#     context "パラメータが異常な場合" do
+#       it "エラーする" do
+#       end
+#     end
+
+#     # TODO: パラメータの条件別テストの実装
+#   end
+# end

--- a/spec/requests/v1/auth/passwords_spec.rb
+++ b/spec/requests/v1/auth/passwords_spec.rb
@@ -1,26 +1,28 @@
-# require "rails_helper"
+require "rails_helper"
 
-# RSpec.describe "V1::Auth::Passwords", type: :request do
-#   describe "POST /update" do
-#     # subject { put(v1_user_password_path, headers: headers) }
+RSpec.describe "V1::Auth::Passwords", type: :request do
+  describe "POST /update" do
+    subject { put(v1_user_password_path, params: params, headers: headers) }
 
-#     context "トークン認証情報がない場合" do
-#       it "エラーする" do
-#       end
-#     end
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
 
-#     # 正常値
-#     context "パラメータが正常な場合" do
-#       it "更新できる" do
-#       end
-#     end
+    context "パラメータが正常な場合" do
+      let(:params) { attributes_for(:password_params, now_password: current_user.password) }
+      it "パスワードが更新できる" do
+        subject
+        expect(response).to have_http_status(:ok)
+        # TOOD: パスワードが更新されたことを検証するテストを追加する
+      end
+    end
 
-#     # 異常値
-#     context "パラメータが異常な場合" do
-#       it "エラーする" do
-#       end
-#     end
-
-#     # TODO: パラメータの条件別テストの実装
-#   end
-# end
+    context "パラメータが異常な場合" do
+      let(:params) { attributes_for(:password_params, :invalid_params, now_password: current_user.password) }
+      it "更新できない" do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+        # TODO: パラメータの条件別テストの実装
+      end
+    end
+  end
+end

--- a/spec/requests/v1/auth/registrations_spec.rb
+++ b/spec/requests/v1/auth/registrations_spec.rb
@@ -47,4 +47,33 @@ RSpec.describe "V1::Auth::Registrations", type: :request do
       end
     end
   end
+
+  # ユーザー更新
+  describe "PUT /v1/auth" do
+    subject { put(v1_user_registration_path, params: params, headers: headers) }
+
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+    context "パラメータが正常な場合" do
+      let(:params) { attributes_for(:user_params) }
+      it "更新できる" do
+        new_user = params
+        expect { subject }.to change { current_user.reload.name }.from(current_user.name).to(new_user[:name])
+                                                                 .and change { current_user.reload.email }.from(current_user.email).to(new_user[:email])
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "パラメータが異常な場合" do
+      let(:params) { attributes_for(:user_params, :invalid_params) }
+      it "更新できない" do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+        # TODO: ワンライナーにしたい。
+        expect { current_user.reload }.not_to change(current_user, :name)
+        expect { current_user.reload }.not_to change(current_user, :email)
+      end
+    end
+  end
 end

--- a/spec/requests/v1/auth/sessions_spec.rb
+++ b/spec/requests/v1/auth/sessions_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "V1::Auth::Sessions", type: :request do
   let(:current_user) { create(:user) }
   let(:headers) { current_user.create_new_auth_token }
 
-  # サインイン
+  # サインイン(ログイン）
   describe "POST /v1/auth/sign_in" do
     subject { post(v1_user_session_path, params: params) }
     before { @user = create(:user) }

--- a/spec/requests/v1/posts_spec.rb
+++ b/spec/requests/v1/posts_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe "V1::Posts", type: :request do
   describe "GET #index" do
     subject { get(v1_posts_path, headers: headers) }
 
-    # context "トークン認証情報がない場合" do
-    #   subject { get(v1_posts_path) }
-    #   let!(:post) { create(:post, user_id: current_user.id) }
-    #   xit "エラーする" do
-    #     subject
-    #     expect(response).to have_http_status(:unauthorized)
-    #   end
-    # end
+    context "トークン認証情報がない場合" do
+      subject { get(v1_posts_path) }
+      let!(:post) { create(:post, user_id: current_user.id) }
+      it "エラーする" do
+        subject
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
 
     before { create_list(:post, 3, user_id: current_user.id) }
     context "ユーザーの投稿が存在するとき" do
@@ -24,7 +24,7 @@ RSpec.describe "V1::Posts", type: :request do
         json = JSON.parse(response.body)
         expect(response).to have_http_status(:ok)
         expect(json.size).to eq 3
-        expect(json[0].keys).to eq %w[id title details]
+        expect(json[0].keys).to eq %w[id title details user_id user]
         expect(json[0]["id"]).to eq Post.last.id
         expect(json[0]["title"]).to eq Post.last.title
         expect(json[0]["details"]).to eq Post.last.details
@@ -34,17 +34,16 @@ RSpec.describe "V1::Posts", type: :request do
 
   describe "POST #create" do
     before { create(:user) }
-    subject { post(v1_posts_path, params: post_params) }
+    subject { post(v1_posts_path, params: post_params, headers: headers) }
     let(:post_params) { { post: attributes_for(:post, user_id: User.first.id) } }
 
-    # TODO: ログイン機能実装後に実装
-    # context 'トークン認証情報がない場合' do
-    #   subject { post(v1_posts_path, params: post_params) }
-    #   it 'エラーする' do
-    #     subject
-    #     expect(response).to have_http_status(:unauthorized)
-    #   end
-    # end
+    context "トークン認証情報がない場合" do
+      subject { post(v1_posts_path, params: post_params) }
+      it "エラーする" do
+        subject
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
 
     context "パラメータが正常なとき" do
       it "データが保存されること" do
@@ -53,31 +52,33 @@ RSpec.describe "V1::Posts", type: :request do
       end
     end
 
-    # context "パラメータが異常なとき" do
-    #   let(:post_params) { { post: attributes_for(:post, :invalid) } }
-    #   it "データが保存されないこと" do
-    #     # expect { subject }.not_to change { Post.count }.by(0)
-    #     expect(response).to have_http_status(:unprocessable_entity)
-    #     json = JSON.parse(response.body)
-    #     expect(json["title"]).to include "を入力してください"
-    #     expect(json["details"]).to include "を入力してください"
-    #   end
-    # end
+    context "パラメータが異常なとき" do
+      let(:post_params) { { post: attributes_for(:post, :invalid) } }
+      xit "データが保存されないこと" do
+        # TODO: 正しい記述を確認する
+        # expect { subject }.not_to change { Post.count }.by(0)
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+        json = JSON.parse(response.body)
+        expect(json).to include "Titleを入力してください"
+        expect(json).to include "Detailsを入力してください"
+      end
+    end
   end
 
   describe "PATCH #update" do
-    subject { patch(v1_post_path(post_id), params: post_params) }
+    subject { patch(v1_post_path(post_id), params: post_params, headers: headers) }
     let(:post) { create(:post, user_id: current_user.id) }
     let(:post_id) { post.id }
 
-    # context "トークン認証情報がない場合" do
-    #   subject { patch(v1_post_path(post_id), params: post_params) }
-    #   let(:post_params) { { post: attributes_for(:post, user_id: current_user.id) } }
-    #   it "エラーする" do
-    #     subject
-    #     expect(response).to have_http_status(:unauthorized)
-    #   end
-    # end
+    context "トークン認証情報がない場合" do
+      subject { patch(v1_post_path(post_id), params: post_params) }
+      let(:post_params) { { post: attributes_for(:post, user_id: current_user.id) } }
+      it "エラーする" do
+        subject
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
 
     context "パラメータが正常の時 && 本人の投稿の場合" do
       let(:post_params) { { post: attributes_for(:post, user_id: current_user.id) } }
@@ -92,53 +93,54 @@ RSpec.describe "V1::Posts", type: :request do
       end
     end
 
-    # context "パラメータが正常の時 && 本人以外の投稿の場合" do
-    #   let(:post_params) { { post: attributes_for(:post, user_id: user.id) } }
-    #   let(:other_post) { create(:post, user_id: user.id) }
-    #   let(:post_id) { other_post.id }
-    #   it "エラーする" do
-    #     expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
-    #   end
-    # end
+    context "パラメータが正常の時 && 本人以外の投稿の場合" do
+      let(:post_params) { { post: attributes_for(:post, user_id: user.id) } }
+      let(:other_post) { create(:post, user_id: user.id) }
+      let(:post_id) { other_post.id }
+      it "エラーする" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
 
-    # context "パラメータが異常なとき" do
-    #   let(:post_params) { { post: attributes_for(:post, :invalid, user_id: current_user.id) } }
-    #   it "投稿が更新されないこと" do
-    #     # expect { subject }.not_to change { post.reload.title }
-    #     # expect { subject }.not_to change { post.reload.details }
-    #     expect(response).to have_http_status(:unprocessable_entity)
-    #     json = JSON.parse(response.body)
-    #     expect(json["title"]).to include "を入力してください"
-    #     expect(json["details"]).to include "を入力してください"
-    #   end
-    # end
+    context "パラメータが異常なとき" do
+      let(:post_params) { { post: attributes_for(:post, :invalid, user_id: current_user.id) } }
+      xit "投稿が更新されないこと" do
+        subject
+        # expect { subject }.not_to change { post.reload.title }
+        # expect { subject }.not_to change { post.reload.details }
+        expect(response).to have_http_status(:unprocessable_entity)
+        json = JSON.parse(response.body)
+        expect(json).to include "Titleを入力してください"
+        expect(json).to include "Detailsを入力してください"
+      end
+    end
   end
 
   describe "DELETE #destroy" do
     subject { delete(v1_post_path(post.id), headers: headers) }
 
     context "本人の投稿の場合" do
-      let!(:post) { create(:post) }
-      xit "投稿が削除されること" do
+      let!(:post) { create(:post, user_id: current_user.id) }
+      it "投稿が削除されること" do
         expect { subject }.to change { Post.count }.by(-1)
-        expect(response).to have_http_status(:no_details)
+        expect(response).to have_http_status(:no_content)
       end
     end
 
-    # context "本人以外の投稿の場合" do
-    #   let!(:post) { create(:post, user_id: user.id) }
-    #   it "エラーする" do
-    #     expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
-    #   end
-    # end
+    context "本人以外の投稿の場合" do
+      let!(:post) { create(:post, user_id: user.id) }
+      it "エラーする" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
 
-    # context "トークン認証情報がない場合" do
-    #   subject { delete(v1_post_path(post.id)) }
-    #   let!(:post) { create(:post, user_id: current_user.id) }
-    #   it "エラーする" do
-    #     subject
-    #     expect(response).to have_http_status(:unauthorized)
-    #   end
-    # end
+    context "トークン認証情報がない場合" do
+      subject { delete(v1_post_path(post.id)) }
+      let!(:post) { create(:post, user_id: current_user.id) }
+      it "エラーする" do
+        subject
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
   end
 end

--- a/spec/requests/v1/posts_spec.rb
+++ b/spec/requests/v1/posts_spec.rb
@@ -54,10 +54,8 @@ RSpec.describe "V1::Posts", type: :request do
 
     context "パラメータが異常なとき" do
       let(:post_params) { { post: attributes_for(:post, :invalid) } }
-      xit "データが保存されないこと" do
-        # TODO: 正しい記述を確認する
-        # expect { subject }.not_to change { Post.count }.by(0)
-        subject
+      it "データが保存されないこと" do
+        expect { subject }.not_to change(Post, :count)
         expect(response).to have_http_status(:unprocessable_entity)
         json = JSON.parse(response.body)
         expect(json).to include "Titleを入力してください"
@@ -104,10 +102,10 @@ RSpec.describe "V1::Posts", type: :request do
 
     context "パラメータが異常なとき" do
       let(:post_params) { { post: attributes_for(:post, :invalid, user_id: current_user.id) } }
-      xit "投稿が更新されないこと" do
+      it "投稿が更新されないこと" do
         subject
-        # expect { subject }.not_to change { post.reload.title }
-        # expect { subject }.not_to change { post.reload.details }
+        expect { post.reload.title }.not_to change(post, :title)
+        expect { post.reload.details }.not_to change(post, :details)
         expect(response).to have_http_status(:unprocessable_entity)
         json = JSON.parse(response.body)
         expect(json).to include "Titleを入力してください"


### PR DESCRIPTION
## 実装の目的と概要
- リクエストスペックを追加(password/auth)
- 壊れていたリクエストスペックを修正

## 実装内容(技術的な点を記載)
### テスト
- password/update
- user/update
- post(skipしていたテスト + コメントアウトしていたテスト)
- 必要なテストデータを作成(factroy_bot)

### その他
- 継承の記述を変更(rubocop/ClassAndModuleChildren)
- haskyの削除(使用しないため、アンインストールした)

 
## 確認用コマンド
```
❯ rspec spec/requests

V1::Auth::Passwords
  POST /update
    パラメータが正常な場合
      パスワードが更新できる
    パラメータが異常な場合
      更新できない

V1::Auth::Registrations
  POST /v1/auth
    パラメータが妥当な場合
      新規登録ができること
      本人認証として使用されるheader情報を取得することができること
    パラメータが不正な場合
      emailが存在しないとき
        エラーが発生する
      passwordが存在しないとき
        エラーが発生する
  PUT /v1/auth
    パラメータが正常な場合
      更新できる
    パラメータが異常な場合
      更新できない

V1::Auth::Sessions
  POST /v1/auth/sign_in
    ユーザーのemailとpasswordが一致している時
      ログインできること
    ユーザーのemailとpasswordが一致しない時
      エラーが発生する
  DELETE /v1/auth/sign_out
    パラメータが正しい場合
      ログアウトできる
    パラメータが不正な場合
      エラーが発生する

V1::Posts
  GET #index
    トークン認証情報がない場合
      エラーする
    ユーザーの投稿が存在するとき
      投稿一覧を取得できること
  POST #create
    トークン認証情報がない場合
      エラーする
    パラメータが正常なとき
      データが保存されること
    パラメータが異常なとき
      データが保存されないこと
  PATCH #update
    トークン認証情報がない場合
      エラーする
    パラメータが正常の時 && 本人の投稿の場合
      投稿が更新されること
    パラメータが正常の時 && 本人以外の投稿の場合
      エラーする
    パラメータが異常なとき
      投稿が更新されないこと
  DELETE #destroy
    本人の投稿の場合
      投稿が削除されること
    本人以外の投稿の場合
      エラーする
    トークン認証情報がない場合
      エラーする

Finished in 1.53 seconds (files took 1.65 seconds to load)
24 examples, 0 failures
```

## 参考資料
- [Factory Bot cheatsheet](https://devhints.io/factory_bot)
- [RSpecで変更が無い事を確認しようとしたらLint/AmbiguousBlockAssociationというLintエラーが発生した](https://qiita.com/dmiya/items/171fd059c337afdda7fa)

## 備考
- 細かいテストは、今回はパスしている。余裕があれば実装したい。